### PR TITLE
dashboards: added additional endpoints for listing sessions and eeg-readings

### DIFF
--- a/backend-server/gamesession/tests/test_models_and_serializers.py
+++ b/backend-server/gamesession/tests/test_models_and_serializers.py
@@ -1,0 +1,99 @@
+import pytest
+from django.utils import timezone
+from unittest import mock
+from gamesession.models import Game, Session, Prescription, EEGReading
+from accounts.models import CustomUser
+from gamesession.serializers import EEGReadingSerializer, PrescriptionSerializer, SessionSerializer, GameSerializer
+
+@pytest.fixture
+def patient_user_data():
+    return {
+        "id": None, # hard-coded here, but logging
+        "email": "dummypatient@gmail.com",
+        "username": "dummy",
+        "password": "abc123",
+        "date_of_birth": None,
+        "is_patient": True,
+    }
+
+@pytest.fixture
+def patient_custom_user(db, patient_user_data):
+    patient_user = CustomUser.objects.create_user(
+        email = patient_user_data['email'],
+        username = patient_user_data['username'],
+        password = patient_user_data['password'],
+        is_patient = patient_user_data['is_patient']
+    )
+    patient_user_data['id'] = patient_user.id
+    return patient_user
+
+@pytest.fixture
+def doctor_user_data():
+    return {
+        "id": None, # hard-coded here, but logging
+        "email": "dummydoctor@gmail.com",
+        "username": "dummy",
+        "password": "abc123",
+        "specialization": None,
+        "is_doctor": True
+    }
+
+@pytest.fixture
+def doctor_custom_user(db, doctor_user_data):
+    doctor_user = CustomUser.objects.create_user(
+        email = doctor_user_data['email'],
+        username = doctor_user_data['username'],
+        password = doctor_user_data['password'],
+        is_doctor = doctor_user_data['is_doctor']
+    )
+    doctor_user_data['id'] = doctor_user.id
+    return doctor_user
+
+@pytest.fixture
+def game_model():
+    return Game.objects.create(
+        name = "MindGame",
+        description = None
+    )
+
+@pytest.fixture
+def prescription_model(doctor_custom_user, patient_custom_user, game_model):
+    mocked_datetime = timezone.datetime(2023, 1, 15, 10, 30, 0)
+    
+    with mock.patch('django.utils.timezone.now', return_value=mocked_datetime):
+
+        prescription = Prescription.objects.create(
+            doctor = doctor_custom_user,
+            patient = patient_custom_user,
+            game = game_model,
+            notes = 'Play twice a week',
+            created_at = mocked_datetime,
+            active = True
+        )
+    return prescription
+
+# +++ TESTS +++
+
+@pytest.mark.django_db
+def test_game_model_creation(game_model):
+    game = game_model
+
+    assert game.name == 'MindGame'
+    assert game.description == None
+
+@pytest.mark.django_db
+def test_prescription_model_creation(prescription_model):
+    prescription = prescription_model
+
+    assert prescription.doctor.email == 'dummydoctor@gmail.com'
+    assert prescription.patient.email == 'dummypatient@gmail.com'
+    assert prescription.game.name == 'MindGame'
+    assert prescription.notes == 'Play twice a week'
+    assert prescription.active == True
+
+    old_created_at = prescription.created_at
+    assert prescription.created_at == old_created_at
+
+@pytest.mark.django_db
+def test_session_model_creation(session_model):
+    session = session_model

--- a/backend-server/gamesession/tests/test_views_api.py
+++ b/backend-server/gamesession/tests/test_views_api.py
@@ -1,0 +1,84 @@
+import pytest
+from rest_framework.test import APIClient
+from django.urls import reverse
+from django.utils import timezone
+from gamesession.models import Game, Prescription, EEGReading, Session
+from accounts.models import CustomUser
+from gamesession import views
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+@pytest.fixture
+def doctor_user(db):
+    return CustomUser.objects.create_user(
+        email="doc@example.com",
+        username="doc",
+        password="pass",
+        is_doctor=True
+    )
+
+@pytest.fixture
+def patient_user(db):
+    return CustomUser.objects.create_user(
+        email="pat@example.com",
+        username="pat",
+        password="pass",
+        is_patient=True
+    )
+
+@pytest.fixture
+def another_patient_user(db):
+    return CustomUser.objects.create_user(
+        email="pat2@example.com",
+        password="pass",
+        is_patient=True
+    )
+
+@pytest.fixture
+def game(db):
+    return Game.objects.create(name="Test Game")
+
+@pytest.fixture
+def session_factory(db, game):
+    def make_session(patient, **kwargs):
+        return Session.objects.create(
+            patient=patient,
+            game=game,
+            start_time=timezone.now(),
+            **kwargs
+        )
+    return make_session
+
+# +++ TESTS +++
+
+@pytest.mark.django_db
+def test_doctor_can_get_patient_sessions(api_client, doctor_user, patient_user, session_factory):
+
+    session1 = session_factory(patient_user)
+    session2 = session_factory(patient_user)
+
+    api_client.force_authenticate(user=doctor_user)
+
+    url = reverse("get_sessions_by_user_id", args=[patient_user.id])
+    response = api_client.get(url)
+
+    assert response.status_code == 200
+    assert len(response.data) == 2
+    assert {s["id"] for s in response.data} == {session1.id, session2.id}
+
+@pytest.mark.django_db
+def test_patient_can_get_their_own_sessions(api_client, patient_user, session_factory):
+    
+    session1 = session_factory(patient_user)
+    session2 = session_factory(patient_user)
+
+    api_client.force_authenticate(user=patient_user)
+
+    url = reverse("get_my_sessions")
+    response = api_client.get(url)
+
+    assert response.status_code == 200
+    assert len(response.data) == 2
+    assert {s["id"] for s in response.data} == {session1.id, session2.id}

--- a/backend-server/gamesession/urls.py
+++ b/backend-server/gamesession/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
-from gamesession.views import EEGReadingCreateView, SessionStartView, SessionEndView, PrescriptionListCreateView, GameListCreateView, SessionListCreateView
+from gamesession.views import EEGReadingCreateView, SessionStartView, SessionEndView, PrescriptionListCreateView, GameListCreateView, SessionListCreateView, GetMySession, GetSessionByUserIDDoctor
 
 # /gamesessions/...
 urlpatterns = [
@@ -9,4 +9,6 @@ urlpatterns = [
     path('sessions/start/', SessionStartView.as_view(), name='session-start'), # start a session
     path('sessions/<int:session_id>/end/', SessionEndView.as_view(), name='session-end'), # end a session
     path('eeg-readings/', EEGReadingCreateView.as_view(), name="eeg-reading-create"), # where Unity streams eeg-data
+    path('sessions/me/',GetMySession.as_view(), name='get_my_sessions'),
+    path('sessions/<int:target_patient_id>/', GetSessionByUserIDDoctor.as_view(), name='get_sessions_by_user_id')
 ]

--- a/backend-server/gamesession/urls.py
+++ b/backend-server/gamesession/urls.py
@@ -1,5 +1,7 @@
 from django.urls import path
-from gamesession.views import EEGReadingCreateView, SessionStartView, SessionEndView, PrescriptionListCreateView, GameListCreateView, SessionListCreateView, GetMySession, GetSessionByUserIDDoctor
+from gamesession.views import (EEGReadingCreateView, SessionStartView, SessionEndView, PrescriptionListCreateView, 
+                               GameListCreateView, SessionListCreateView, GetMySession, GetSessionByUserIDDoctor,
+                               GetEEGBySessionIDDoctor, GetMyEEGBySession)
 
 # /gamesessions/...
 urlpatterns = [
@@ -9,6 +11,12 @@ urlpatterns = [
     path('sessions/start/', SessionStartView.as_view(), name='session-start'), # start a session
     path('sessions/<int:session_id>/end/', SessionEndView.as_view(), name='session-end'), # end a session
     path('eeg-readings/', EEGReadingCreateView.as_view(), name="eeg-reading-create"), # where Unity streams eeg-data
-    path('sessions/me/',GetMySession.as_view(), name='get_my_sessions'),
-    path('sessions/<int:target_patient_id>/', GetSessionByUserIDDoctor.as_view(), name='get_sessions_by_user_id')
+
+    # viewing sessions
+    path('sessions/me/',GetMySession.as_view(), name='get_my_sessions'), # patient only
+    path('sessions/<int:target_patient_id>/', GetSessionByUserIDDoctor.as_view(), name='get_sessions_by_user_id'), # doctor only
+
+    # viewing eeg readings
+    path('sessions/me/<int_target_session_id>/eeg/', GetMyEEGBySession.as_view(), name='get_my_eeg_by_session'), # patient only 
+    path('sessions/<int:target_session_id>/<int:target_patient_id/eeg/', GetEEGBySessionIDDoctor.as_view(), name='get_eeg_by_session_doctor'), # doctor only
 ]

--- a/backend-server/gamesession/views.py
+++ b/backend-server/gamesession/views.py
@@ -68,6 +68,10 @@ class SessionListCreateView(APIView):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
     
 class GetSessionByUserIDDoctor(APIView):
+    """
+    For doctors.
+    Returns list of all sessions associated to the ID of the patient passed into the URL.
+    """
     permission_classes = [IsAuthenticated]
 
     def get(self, request, target_patient_id):
@@ -89,6 +93,10 @@ class GetSessionByUserIDDoctor(APIView):
         return Response(serializer.data, status=status.HTTP_200_OK)
 
 class GetMySession(APIView):
+    """
+    For patients.
+    Returns list of all sessions associated to the logged-in patient.
+    """
     permission_classes = [IsAuthenticated]
 
     def get(self, request):
@@ -157,3 +165,55 @@ class EEGReadingCreateView(APIView):
             serializer.save()
             return Response(serializer.data, status=status.HTTP_201_CREATED)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+    
+class GetEEGBySessionIDDoctor(APIView):
+    """
+    For doctors.
+    Returns all the eeg-readings of a particular session (target_session_id) by a particular patient (target_user_id).
+    """
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, target_session_id, target_patient_id):
+        user = request.user
+
+        if not user.is_doctor:
+            return Response("doctor only action", status=status.HTTP_403_FORBIDDEN)
+        
+        try:
+            target_user = CustomUser.objects.get(id=target_patient_id)
+        except CustomUser.DoesNotExist:
+            return Response({"error": f"record with ID {target_patient_id} not found"}, status=status.HTTP_404_NOT_FOUND)
+        
+        if target_user.is_doctor:
+            return Response("cannot view other doctors' sessions", status=status.HTTP_403_FORBIDDEN)
+
+        try:
+            target_session = Session.objects.get(id=target_session_id, patient=target_user)
+        except Session.DoesNotExist:
+            return Response({"error": f"session with ID {target_session_id} not found"}, status=status.HTTP_404_NOT_FOUND)
+        
+        eeg_readings = target_session.egg_readings.all()
+        serializer = EEGReadingSerializer(eeg_readings, many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+    
+class GetMyEEGBySession(APIView):
+    """
+    For patients.
+    Returns list of a patient's own eeg-readings associated to a particular session.
+    """
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, target_session_id):
+        user = request.user
+
+        if not user.is_patient:
+            return Response("patient only action", status=status.HTTP_403_FORBIDDEN)
+        
+        try:
+            target_session = Session.objects.get(id=target_session_id, patient=user)
+        except Session.DoesNotExist:
+            return Response({"error": f"session with ID {target_session_id} not found"}, status=status.HTTP_404_NOT_FOUND)
+        
+        eeg_readings = target_session.eeg_readings.all()
+        serializer = EEGReadingSerializer(eeg_readings, many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
### **Get sessions by user ID**
distinct patient (`get_my_sessions`) and doctor (`get_sessions_by_user_id`) only endpoints
- `get_my_sessions`: Returns list of all sessions associated to the logged-in patient.
- `get_sessions_by_user_id`: Returns list of all sessions associated to the ID of the patient passed into the URL.

### **Get eeg-readings by session ID**
distinct patient (`get_my_eeg_by_session`) and doctor (`get_eeg_by_session_doctor`) only endpoints
- `get_my_eeg_by_session`: Returns list of a patient's own eeg-readings associated to a particular session.
- `get_eeg_by_session_doctor`: Returns all the eeg-readings of a particular session (target_session_id) by a particular patient (target_user_id).

additional testing reccomended